### PR TITLE
skip over the header record

### DIFF
--- a/Reading & Writing CSV Files Answers_1.ipynb
+++ b/Reading & Writing CSV Files Answers_1.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1.We're working with a list of flowers and some information about each one. The create_file function writes this information to a CSV file. The contents_of_file function reads this file into records and returns the information in a nicely formatted block. Fill in the gaps of the contents_of_file function to turn the data in the CSV file into a dictionary using DictReader."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a pink carnation is annual\n",
+      "a yellow daffodil is perennial\n",
+      "a blue iris is perennial\n",
+      "a red poinsettia is perennial\n",
+      "a yellow sunflower is annual\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import csv\n",
+    "\n",
+    "# Create a file with data in it\n",
+    "def create_file(filename):\n",
+    "  with open(filename, \"w\") as file:\n",
+    "    file.write(\"name,color,type\\n\")\n",
+    "    file.write(\"carnation,pink,annual\\n\")\n",
+    "    file.write(\"daffodil,yellow,perennial\\n\")\n",
+    "    file.write(\"iris,blue,perennial\\n\")\n",
+    "    file.write(\"poinsettia,red,perennial\\n\")\n",
+    "    file.write(\"sunflower,yellow,annual\\n\")\n",
+    "\n",
+    "# Read the file contents and format the information about each row\n",
+    "def contents_of_file(filename):\n",
+    "  return_string = \"\"\n",
+    "\n",
+    "  # Call the function to create the file \n",
+    "  create_file(filename)\n",
+    "\n",
+    "  # Open the file\n",
+    "  with open(filename) as file:\n",
+    "    # Read the rows of the file into a dictionary\n",
+    "    rows = csv.DictReader(file)\n",
+    "    # Process each item of the dictionary\n",
+    "    for row in rows:\n",
+    "      return_string += \"a {} {} is {}\\n\".format(row[\"color\"], row[\"name\"], row[\"type\"])\n",
+    "  return return_string\n",
+    "\n",
+    "#Call the function\n",
+    "print(contents_of_file(\"flowers.csv\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "2.Using the CSV file of flowers again, fill in the gaps of the contents_of_file function to process the data without turning it into a dictionary. How do you skip over the header record with the field names?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a pink carnation is annual\n",
+      "a yellow daffodil is perennial\n",
+      "a blue iris is perennial\n",
+      "a red poinsettia is perennial\n",
+      "a yellow sunflower is annual\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import csv\n",
+    "\n",
+    "# Create a file with data in it\n",
+    "def create_file(filename):\n",
+    "  with open(filename, \"w\") as file:\n",
+    "    file.write(\"name,color,type\\n\")\n",
+    "    file.write(\"carnation,pink,annual\\n\")\n",
+    "    file.write(\"daffodil,yellow,perennial\\n\")\n",
+    "    file.write(\"iris,blue,perennial\\n\")\n",
+    "    file.write(\"poinsettia,red,perennial\\n\")\n",
+    "    file.write(\"sunflower,yellow,annual\\n\")\n",
+    "\n",
+    "# Read the file contents and format the information about each row\n",
+    "def contents_of_file(filename):\n",
+    "  return_string = \"\"\n",
+    "\n",
+    "  # Call the function to create the file \n",
+    "  create_file(filename)\n",
+    "\n",
+    "  # Open the file\n",
+    "  with open(filename) as file:\n",
+    "    # Read the rows of the file\n",
+    "    rows = csv.reader(file)\n",
+    "    next(rows)\n",
+    "    # Process each row\n",
+    "    for row in rows:\n",
+    "      name, color, type = row\n",
+    "      # Format the return string for data rows only\n",
+    "\n",
+    "      return_string += \"a {} {} is {}\\n\".format(color,name,type)\n",
+    "  return return_string\n",
+    "\n",
+    "#Call the function\n",
+    "print(contents_of_file(\"flowers.csv\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "3.In order to use the writerows() function of DictWriter() to write a list of dictionaries to each line of a CSV file, what steps should we take? (Check all that apply)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "A]Create an instance of the DictWriter() class\n",
+    "\n",
+    "Correct\n",
+    "Excellent! We have to create a DictWriter() object instance to work with, and pass to it the fieldnames parameter defined as a list of keys.\n",
+    "\n",
+    "\n",
+    "B]Write the fieldnames parameter into the first row using writeheader()\n",
+    "\n",
+    "Correct\n",
+    "Nice work! The non-optional fieldnames parameter list values should be written to the first row.\n",
+    "\n",
+    "\n",
+    "C]Open the csv file using with open\n",
+    "\n",
+    "Correct\n",
+    "Good call! The CSV file has to be open before we can write to it.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "4.Which of the following is true about unpacking values into variables when reading rows of a CSV file? (Check all that apply)\n",
+    "\n",
+    "\n",
+    "A]We need the same amount of variables as there are columns of data in the CSV\n",
+    "\n",
+    "Correct\n",
+    "Awesome! We need to have the exact same amount of variables on the left side of the equals sign as the length of the sequence on the right side when unpacking rows into individual variables.\n",
+    "\n",
+    "\n",
+    "Rows can be read using both csv.reader and csv.DictReader\n",
+    "\n",
+    "Correct\n",
+    "Right on! Although they read the CSV rows into different datatypes, both csv.reader or csv.DictReader can be used to parse CSV files.\n",
+    "\n",
+    "\n",
+    "An instance of the reader class must be created first\n",
+    "\n",
+    "Correct\n",
+    "Nice job! We have to create an instance of the reader class we are using before we can parse the CSV file.\n",
+    "\n",
+    "\n",
+    "The CSV file does not have to be explicitly opened\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Using the CSV file of flowers again, fill in the gaps of the contents_of_file function to process the data without turning it into a dictionary. How do you skip over the header record with the field names? = solved